### PR TITLE
Add DCC menus for texture loader addon

### DIFF
--- a/client/texture_loader/addon.py
+++ b/client/texture_loader/addon.py
@@ -1,22 +1,52 @@
-import os
-import subprocess
-import typing
-from typing import Optional, List, Dict, Any, Tuple
+"""Texture Loader addon entry point."""
 
-import requests
-import ayon_api
+import os
+from typing import Any, Dict, List
 
 from ayon_core.addon import AYONAddon, IPluginPaths
 from ayon_core.lib import CacheItem
 
 from .version import __version__
 
+
 class TextureLoaderAddon(AYONAddon, IPluginPaths):
+    """Addon providing texture loading tools for multiple hosts."""
+
     name = "texture_loader"
     version = __version__
 
-    def initialize(self, studio_settings):
-        self.log.info((
-            "Texture Loader Addon initialized successfully."
-        ))
+    def initialize(self, studio_settings: Dict[str, Any]) -> None:
+        """Initialize the addon."""
+        self.log.info("Texture Loader Addon initialized successfully.")
         self._local_settings_cache = CacheItem(lifetime=60)
+
+    @staticmethod
+    def get_plugin_paths() -> Dict[str, List[str]]:
+        """Return plug-in paths for supported DCC hosts."""
+        base = os.path.dirname(__file__)
+        return {
+            "maya": [os.path.join(base, "plugins", "maya")],
+            "houdini": [os.path.join(base, "plugins", "houdini")],
+            "nuke": [os.path.join(base, "plugins", "nuke")],
+        }
+
+    def install(self) -> None:
+        """Install host-specific menus."""
+        host = os.environ.get("AYON_HOST")
+        if host == "maya":
+            try:
+                from .plugins import maya as maya_plugins
+
+                maya_plugins.install()
+            except Exception:  # noqa: BLE001
+                self.log.warning("Failed to install Maya menu", exc_info=True)
+        elif host == "nuke":
+            try:
+                from .plugins import nuke as nuke_plugins
+
+                nuke_plugins.install()
+            except Exception:  # noqa: BLE001
+                self.log.warning("Failed to install Nuke menu", exc_info=True)
+        elif host == "houdini":
+            # Menu defined in Houdini XML plugin
+            pass

--- a/client/texture_loader/plugins/houdini/startup/MainMenuCommon.xml
+++ b/client/texture_loader/plugins/houdini/startup/MainMenuCommon.xml
@@ -182,5 +182,15 @@ update_placeholder()
                 </scriptItem>
             </subMenu>
         </subMenu>
+        <subMenu id="fireframe_menu">
+            <label>Fireframe</label>
+            <scriptItem id="texture_loader">
+                <label>Texture Loader</label>
+                <scriptCode><![CDATA[
+import hou
+hou.ui.displayMessage("Texture Loader Addon loaded successfully")
+]]></scriptCode>
+            </scriptItem>
+        </subMenu>
     </menuBar>
 </mainMenu>

--- a/client/texture_loader/plugins/maya/__init__.py
+++ b/client/texture_loader/plugins/maya/__init__.py
@@ -1,0 +1,22 @@
+"""Maya integration for the Texture Loader addon."""
+
+from maya import cmds, mel
+
+
+def install() -> None:
+    """Create Fireframe menu with Texture Loader item in Maya."""
+    main_window = mel.eval("$tmp=$gMainWindow")
+    if cmds.menu("fireframeMenu", exists=True):
+        cmds.deleteUI("fireframeMenu")
+    fireframe_menu = cmds.menu(
+        "fireframeMenu", label="Fireframe", parent=main_window
+    )
+    cmds.menuItem(
+        label="Texture Loader",
+        parent=fireframe_menu,
+        command=lambda *_: cmds.confirmDialog(
+            title="Texture Loader",
+            message="Texture Loader Addon loaded successfully",
+            button=["OK"],
+        ),
+    )

--- a/client/texture_loader/plugins/nuke/__init__.py
+++ b/client/texture_loader/plugins/nuke/__init__.py
@@ -1,0 +1,15 @@
+"""Nuke integration for the Texture Loader addon."""
+
+import nuke
+
+
+def install() -> None:
+    """Create Fireframe menu with Texture Loader item in Nuke."""
+    toolbar = nuke.menu("Nuke")
+    fireframe_menu = toolbar.findItem("Fireframe")
+    if fireframe_menu is None:
+        fireframe_menu = toolbar.addMenu("Fireframe")
+    fireframe_menu.addCommand(
+        "Texture Loader",
+        lambda: nuke.message("Texture Loader Addon loaded successfully"),
+    )


### PR DESCRIPTION
## Summary
- register plugin paths and install host-specific menus
- add Maya and Nuke integration to launch texture loader
- expose Fireframe menu in Houdini XML

## Testing
- `ruff check --no-cache client/texture_loader/addon.py client/texture_loader/plugins/maya/__init__.py client/texture_loader/plugins/nuke/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adbe90bbe08326b1285a4af6aaa9c7